### PR TITLE
Fix @[Link] to use __DIR__ ldflags for downstream consumer linking

### DIFF
--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -6,23 +6,18 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    
+
     container:
-      image: crystallang/crystal:1.0.0
-    
+      image: crystallang/crystal:1.14.0
+
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/checkout@v2
-      with:
-        repository: uber/h3
-        ref: v3.6.0
-        path: h3-3.6.0
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         apt-get update -y
         apt-get install cmake make gcc libtool -y
-        cd h3-3.6.0; cmake .; make install
-        cd ..; shards install
+        make -C ext
+        shards install
     - name: Linting
       run: |
         crystal tool format --check

--- a/README.md
+++ b/README.md
@@ -33,9 +33,24 @@ Before installing the shard, please install the build dependencies for your syst
 
 ```crystal
 require "h3_crystal/h3"
+
+# Convert coordinates to an H3 index
+index = H3.from_geo_coordinates({40.689167, -74.044444}, 8)
+# => 613229551440363519
+
+# Inspect the index
+H3.valid?(index)     # => true
+H3.resolution(index) # => 8
+
+# Convert back to coordinates
+H3.to_geo_coordinates(index)
+# => {40.68762931583634, -74.04099997186306}
+
+# Find neighboring hexagons
+H3.k_ring(index, 1) # => 7 hexagons
 ```
 
-TODO: Write usage instructions here
+All public methods are called as `H3.method_name`. See the [H3 documentation](https://uber.github.io/h3/#/documentation/overview/introduction) for details on available operations.
 
 ## Development
 

--- a/ext/Makefile
+++ b/ext/Makefile
@@ -1,5 +1,5 @@
 make:
-	cd h3-3.6.0; cmake . -DBUILD_SHARED_LIBS=true -DBUILD_FILTERS=OFF -DBUILD_BENCHMARKS=OFF; make
+	cd h3-3.6.0; cmake . -DBUILD_SHARED_LIBS=false -DBUILD_FILTERS=OFF -DBUILD_BENCHMARKS=OFF; make
 install:
 	: # do nothing, we'll load the lib directly
 clean:

--- a/src/h3/bindings/lib_h3.cr
+++ b/src/h3/bindings/lib_h3.cr
@@ -5,7 +5,7 @@ module H3
     module Private
       include Types
 
-      @[Link("h3")]
+      @[Link(ldflags: "#{__DIR__}/../../../ext/h3-3.6.0/lib/libh3.a -lm")]
       lib LibH3
         alias H3Index = UInt64
 
@@ -65,7 +65,7 @@ module H3
         fun h3_to_children = h3ToChildren(h3_index : H3Index, res : Int32, h3_indexes_out : H3Index*) : Void
         fun compact = compact(h3_set : H3Index*, compacted_set : H3Index*, size : Int32) : Bool
         fun max_uncompact_size = maxUncompactSize(h3_set : H3Index*, size : LibC::SizeT, res : Int32) : Int32
-        fun uncompact = uncompact(h3_set : H3Index*, size : LibC::SizeT, h3_indexes_out : H3Index*, size : LibC::SizeT, res : Int32) : Bool
+        fun uncompact = uncompact(h3_set : H3Index*, size : LibC::SizeT, h3_indexes_out : H3Index*, max_hexes : LibC::SizeT, res : Int32) : Bool
         fun center_child = h3ToCenterChild(h3_index : H3Index, res : Int32) : UInt64
       end
 


### PR DESCRIPTION
## Summary
- Switch H3 cmake build from shared to static (`-DBUILD_SHARED_LIBS=false`) to avoid runtime `LD_LIBRARY_PATH` issues
- Replace `@[Link("h3")]` with `@[Link(ldflags: "#{__DIR__}/../../../ext/h3-3.6.0/lib/libh3.a -lm")]` so downstream shard consumers can link without manual path configuration
- Fix pre-existing duplicate `size` parameter name in `uncompact` FFI declaration (blocked compilation on Crystal 1.0+)
- Add usage examples to README
- Update CI: bump Crystal image to 1.14.0, actions/checkout to v4, use bundled H3 instead of system-wide install

## Test plan
- [x] All 90 specs pass locally
- [x] `crystal tool format --check` passes
- [x] Created a new Crystal app, added h3_crystal as a shard dependency, ran `shards install` + `crystal build` — compiled and linked with zero manual path configuration
- [x] Downstream test app successfully called `from_geo_coordinates`, `valid?`, `resolution`, `to_geo_coordinates`, and `k_ring`
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)