### PR TITLE
[h3-wbb] Add child position and hierarchy utility bindings

### DIFF
--- a/spec/h3/hierarchy_spec.cr
+++ b/spec/h3/hierarchy_spec.cr
@@ -194,4 +194,66 @@ describe H3 do
 
     it { center_child.should eq result }
   end
+
+  describe ".cell_to_child_pos" do
+    h3_index = "8928308280fffff".to_u64(16)
+    parent_resolution = 8
+
+    child_pos = H3.cell_to_child_pos(h3_index, parent_resolution)
+
+    it "returns a non-negative position" do
+      child_pos.should be >= 0
+    end
+
+    context "when the child is the center child of its parent" do
+      parent = H3.parent(h3_index, parent_resolution)
+      center = H3.center_child(parent, 9)
+      center_pos = H3.cell_to_child_pos(center, parent_resolution)
+
+      it "returns position 0 for the center child" do
+        center_pos.should eq 0
+      end
+    end
+
+    context "when the resolution is invalid" do
+      it "raises an error" do
+        expect_raises(Exception) do
+          H3.cell_to_child_pos(h3_index, 16)
+        end
+      end
+    end
+  end
+
+  describe ".child_pos_to_cell" do
+    h3_index = "8928308280fffff".to_u64(16)
+    parent_resolution = 8
+    child_resolution = 9
+
+    parent = H3.parent(h3_index, parent_resolution)
+
+    context "when position is 0" do
+      child = H3.child_pos_to_cell(0_i64, parent, child_resolution)
+
+      it "returns the center child" do
+        child.should eq H3.center_child(parent, child_resolution)
+      end
+    end
+
+    context "round-trip: cell_to_child_pos then child_pos_to_cell" do
+      pos = H3.cell_to_child_pos(h3_index, parent_resolution)
+      recovered = H3.child_pos_to_cell(pos, parent, child_resolution)
+
+      it "recovers the original child cell" do
+        recovered.should eq h3_index
+      end
+    end
+
+    context "when the resolution is invalid" do
+      it "raises an error" do
+        expect_raises(Exception) do
+          H3.child_pos_to_cell(0_i64, parent, 16)
+        end
+      end
+    end
+  end
 end

--- a/src/h3/bindings/lib_h3.cr
+++ b/src/h3/bindings/lib_h3.cr
@@ -68,6 +68,8 @@ module H3
         fun max_uncompact_size = uncompactCellsSize(h3_set : H3Index*, size : Int64, res : Int32, out : Int64*) : H3Error
         fun uncompact = uncompactCells(h3_set : H3Index*, size : Int64, h3_indexes_out : H3Index*, max_hexes : Int64, res : Int32) : H3Error
         fun center_child = cellToCenterChild(h3_index : H3Index, res : Int32, out : H3Index*) : H3Error
+        fun cell_to_child_pos = cellToChildPos(child : H3Index, parent_res : Int32, out : Int64*) : H3Error
+        fun child_pos_to_cell = childPosToCell(child_pos : Int64, parent : H3Index, child_res : Int32, out : H3Index*) : H3Error
       end
 
       def read_array_of_uint64(ptr : Pointer(UInt64), size : Int) : Array(UInt64)

--- a/src/h3/hierarchy.cr
+++ b/src/h3/hierarchy.cr
@@ -174,4 +174,47 @@ module Hierarchy
 
     read_array_of_uint64(output, max_size)
   end
+
+  # Returns the position of the child cell within an ordered list of all
+  # children of the child's parent at the given resolution.
+  #
+  # @param [Integer] child A valid H3 child index.
+  # @param [Integer] parent_resolution The resolution of the parent.
+  #
+  # @example Get the position of a child within its parent's children.
+  #   H3.cell_to_child_pos(617700169982672895, 8)
+  #   0
+  #
+  # @raise [Exception] If the function fails (e.g., invalid resolution).
+  #
+  # @return [Integer] Position of child within parent's children.
+  def cell_to_child_pos(child : UInt64, parent_resolution : Int32) : Int64
+    result = 0_i64
+    err = LibH3.cell_to_child_pos(child, Resolution.new(parent_resolution), pointerof(result))
+    raise Exception.new("Couldn't get child position") if err != 0
+
+    result
+  end
+
+  # Returns the child cell at the given position within an ordered list of
+  # all children of the given parent cell at the given resolution.
+  #
+  # @param [Integer] child_pos The position of the child.
+  # @param [Integer] parent A valid H3 parent index.
+  # @param [Integer] child_resolution The resolution of the child.
+  #
+  # @example Get the child cell at a given position.
+  #   H3.child_pos_to_cell(0, 613196570357137407, 9)
+  #   617700169982672895
+  #
+  # @raise [Exception] If the function fails (e.g., invalid resolution or position).
+  #
+  # @return [Integer] H3 index of child cell at the given position.
+  def child_pos_to_cell(child_pos : Int64, parent : UInt64, child_resolution : Int32) : UInt64
+    result = 0_u64
+    err = LibH3.child_pos_to_cell(child_pos, parent, Resolution.new(child_resolution), pointerof(result))
+    raise Exception.new("Couldn't get child cell from position") if err != 0
+
+    result
+  end
 end


### PR DESCRIPTION
## Summary
- Added FFI bindings for `cellToChildPos` and `childPosToCell` to `lib_h3.cr`
- Added Crystal wrapper methods (`cell_to_child_pos`, `child_pos_to_cell`) to hierarchy module
- Added 6 specs covering valid inputs, round-trips, and invalid resolution errors
- All 96 tests pass (90 existing + 6 new)

Implements h3-wbb

## Test plan
- [x] `crystal spec --verbose` passes all tests
- [x] New hierarchy specs cover cellToChildPos and childPosToCell
- [x] `crystal tool format --check` passes
- [x] CI build passes