### PR TITLE
[h3-kug] Add polygon/polyfill bindings (new in v4 port)

### DIFF
--- a/spec/h3/polygon_spec.cr
+++ b/spec/h3/polygon_spec.cr
@@ -1,0 +1,159 @@
+describe H3 do
+  # A polygon roughly covering part of San Francisco
+  sf_polygon = [
+    {37.813318, -122.4089866},
+    {37.7866302, -122.3805436},
+    {37.7198061, -122.3544736},
+    {37.7076131, -122.5123436},
+  ]
+
+  describe ".max_polygon_to_cells_size" do
+    context "with a simple polygon at resolution 9" do
+      resolution = 9
+
+      max_size = H3.max_polygon_to_cells_size(sf_polygon, resolution)
+
+      it "returns a positive number" do
+        max_size.should be > 0
+      end
+    end
+
+    context "with a lower resolution" do
+      resolution = 5
+
+      max_size = H3.max_polygon_to_cells_size(sf_polygon, resolution)
+
+      it "returns a smaller number than higher resolution" do
+        max_size_high = H3.max_polygon_to_cells_size(sf_polygon, 9)
+        max_size.should be < max_size_high
+      end
+    end
+
+    context "when resolution is invalid" do
+      it "raises an error" do
+        expect_raises(Exception) do
+          H3.max_polygon_to_cells_size(sf_polygon, 16)
+        end
+      end
+    end
+  end
+
+  describe ".polygon_to_cells" do
+    context "with a simple polygon at resolution 9" do
+      resolution = 9
+
+      cells = H3.polygon_to_cells(sf_polygon, resolution)
+
+      it "returns a non-empty array" do
+        cells.size.should be > 0
+      end
+
+      it "returns valid H3 indexes" do
+        cells.each do |cell|
+          H3.valid?(cell).should be_true
+        end
+      end
+
+      it "returns cells at the correct resolution" do
+        cells.each do |cell|
+          H3.resolution(cell).should eq resolution
+        end
+      end
+    end
+
+    context "with a lower resolution" do
+      resolution = 5
+
+      cells = H3.polygon_to_cells(sf_polygon, resolution)
+
+      it "returns fewer cells than at a higher resolution" do
+        cells_high = H3.polygon_to_cells(sf_polygon, 9)
+        cells.size.should be < cells_high.size
+      end
+    end
+
+    context "with a polygon containing a hole" do
+      hole = [
+        {37.78, -122.42},
+        {37.76, -122.42},
+        {37.76, -122.39},
+        {37.78, -122.39},
+      ]
+      resolution = 9
+
+      cells_with_hole = H3.polygon_to_cells(sf_polygon, resolution, holes: [hole])
+      cells_without_hole = H3.polygon_to_cells(sf_polygon, resolution)
+
+      it "returns fewer cells than without a hole" do
+        cells_with_hole.size.should be < cells_without_hole.size
+      end
+    end
+
+    context "when resolution is invalid" do
+      it "raises an error" do
+        expect_raises(Exception) do
+          H3.polygon_to_cells(sf_polygon, 16)
+        end
+      end
+    end
+  end
+
+  describe ".cells_to_multi_polygon" do
+    context "with a single cell" do
+      cells = [H3_VALID_INDEX.to_u64]
+
+      result = H3.cells_to_multi_polygon(cells)
+
+      it "returns a non-empty result" do
+        result.size.should be > 0
+      end
+
+      it "returns at least one polygon with at least one loop" do
+        result.first.size.should be > 0
+      end
+
+      it "returns loops with coordinates" do
+        result.first.first.size.should be > 0
+      end
+
+      it "returns valid coordinate pairs" do
+        result.first.first.each do |lat, lng|
+          lat.should be >= -90.0
+          lat.should be <= 90.0
+          lng.should be >= -180.0
+          lng.should be <= 180.0
+        end
+      end
+    end
+
+    context "with contiguous cells" do
+      origin = H3_VALID_INDEX.to_u64
+      cells = H3.k_ring(origin, 1).map(&.to_u64)
+
+      result = H3.cells_to_multi_polygon(cells)
+
+      it "returns a single polygon" do
+        result.size.should eq 1
+      end
+
+      it "returns a polygon with one outer loop" do
+        result.first.size.should eq 1
+      end
+    end
+
+    context "round-trip: polygon_to_cells then cells_to_multi_polygon" do
+      resolution = 7
+      cells = H3.polygon_to_cells(sf_polygon, resolution)
+      result = H3.cells_to_multi_polygon(cells)
+
+      it "produces a non-empty polygon output" do
+        result.size.should be > 0
+      end
+
+      it "produces loops with coordinates" do
+        total_coords = result.sum { |poly| poly.sum { |loop| loop.size } }
+        total_coords.should be > 0
+      end
+    end
+  end
+end

--- a/src/h3.cr
+++ b/src/h3.cr
@@ -8,6 +8,7 @@ require "./h3/indexing"
 require "./h3/inspection"
 require "./h3/traversal"
 require "./h3/hierarchy"
+require "./h3/polygon"
 
 module H3
   VERSION = "4.4.1"
@@ -17,4 +18,5 @@ module H3
   extend Inspection
   extend Traversal
   extend Hierarchy
+  extend Polygon
 end

--- a/src/h3/bindings/lib_h3.cr
+++ b/src/h3/bindings/lib_h3.cr
@@ -19,6 +19,39 @@ module H3
           verts : LatLng[10]
         end
 
+        struct GeoLoop
+          num_verts : Int32
+          verts : Pointer(LatLng)
+        end
+
+        struct GeoPolygon
+          geoloop : GeoLoop
+          num_holes : Int32
+          holes : Pointer(GeoLoop)
+        end
+
+        struct GeoMultiPolygon
+          num_polygons : Int32
+          polygons : Pointer(GeoPolygon)
+        end
+
+        struct LinkedLatLng
+          vertex : LatLng
+          next : Pointer(LinkedLatLng)
+        end
+
+        struct LinkedGeoLoop
+          first : Pointer(LinkedLatLng)
+          last : Pointer(LinkedLatLng)
+          next : Pointer(LinkedGeoLoop)
+        end
+
+        struct LinkedGeoPolygon
+          first : Pointer(LinkedGeoLoop)
+          last : Pointer(LinkedGeoLoop)
+          next : Pointer(LinkedGeoPolygon)
+        end
+
         # Misc
         fun degs_to_rads = degsToRads(degrees : Float64) : Float64
         fun rads_to_degs = radsToDegs(rads : Float64) : Float64
@@ -70,6 +103,12 @@ module H3
         fun center_child = cellToCenterChild(h3_index : H3Index, res : Int32, out : H3Index*) : H3Error
         fun cell_to_child_pos = cellToChildPos(child : H3Index, parent_res : Int32, out : Int64*) : H3Error
         fun child_pos_to_cell = childPosToCell(child_pos : Int64, parent : H3Index, child_res : Int32, out : H3Index*) : H3Error
+
+        # Polygon
+        fun max_polygon_to_cells_size = maxPolygonToCellsSize(geo_polygon : Pointer(GeoPolygon), res : Int32, flags : UInt32, out : Int64*) : H3Error
+        fun polygon_to_cells = polygonToCells(geo_polygon : Pointer(GeoPolygon), res : Int32, flags : UInt32, out : H3Index*) : H3Error
+        fun cells_to_linked_multi_polygon = cellsToLinkedMultiPolygon(h3_set : H3Index*, num_hexes : Int32, out : Pointer(LinkedGeoPolygon)) : H3Error
+        fun destroy_linked_multi_polygon = destroyLinkedMultiPolygon(polygon : Pointer(LinkedGeoPolygon)) : Void
       end
 
       def read_array_of_uint64(ptr : Pointer(UInt64), size : Int) : Array(UInt64)

--- a/src/h3/polygon.cr
+++ b/src/h3/polygon.cr
@@ -1,0 +1,158 @@
+require "./bindings/base"
+require "./miscellaneous"
+
+module Polygon
+  include H3::Bindings::Base
+  include Miscellaneous
+
+  # Derive the maximum number of H3 cells that could fill a given polygon
+  # at the specified resolution.
+  #
+  # @param [Array<Tuple(Float64, Float64)>] polygon Outer boundary coordinates (lat, lng) in degrees.
+  # @param [Array<Array<Tuple(Float64, Float64)>>] holes Interior boundary (hole) coordinates in degrees.
+  # @param [Integer] resolution The desired H3 resolution (0-15).
+  # @param [Integer] flags Containment mode flags (default 0 = center containment).
+  #
+  # @example Get the max number of cells for a polygon.
+  #   polygon = [{37.813318, -122.4089866}, {37.7866302, -122.3805436}, {37.7198061, -122.3544736}, {37.7076131, -122.5123436}]
+  #   H3.max_polygon_to_cells_size(polygon, 9)
+  #
+  # @return [Integer] Maximum number of H3 cells.
+  def max_polygon_to_cells_size(polygon : Array(Tuple(Float64, Float64)), resolution : Int32, holes : Array(Array(Tuple(Float64, Float64))) = [] of Array(Tuple(Float64, Float64)), flags : UInt32 = 0_u32) : Int64
+    geo_polygon = build_geo_polygon(polygon, holes)
+    count = 0_i64
+    err = LibH3.max_polygon_to_cells_size(pointerof(geo_polygon), Resolution.new(resolution), flags, pointerof(count))
+    raise Exception.new("Couldn't estimate max polygon to cells size") if err != 0
+
+    count
+  end
+
+  # Fill a polygon with H3 cells at the specified resolution.
+  #
+  # @param [Array<Tuple(Float64, Float64)>] polygon Outer boundary coordinates (lat, lng) in degrees.
+  # @param [Array<Array<Tuple(Float64, Float64)>>] holes Interior boundary (hole) coordinates in degrees.
+  # @param [Integer] resolution The desired H3 resolution (0-15).
+  # @param [Integer] flags Containment mode flags (default 0 = center containment).
+  #
+  # @example Fill a polygon with H3 cells.
+  #   polygon = [{37.813318, -122.4089866}, {37.7866302, -122.3805436}, {37.7198061, -122.3544736}, {37.7076131, -122.5123436}]
+  #   H3.polygon_to_cells(polygon, 9)
+  #
+  # @return [Array<Integer>] Array of H3 indexes filling the polygon.
+  def polygon_to_cells(polygon : Array(Tuple(Float64, Float64)), resolution : Int32, holes : Array(Array(Tuple(Float64, Float64))) = [] of Array(Tuple(Float64, Float64)), flags : UInt32 = 0_u32) : Array(UInt64)
+    geo_polygon = build_geo_polygon(polygon, holes)
+    max_size = 0_i64
+    err = LibH3.max_polygon_to_cells_size(pointerof(geo_polygon), Resolution.new(resolution), flags, pointerof(max_size))
+    raise Exception.new("Couldn't estimate max polygon to cells size") if err != 0
+    return [] of UInt64 if max_size <= 0
+
+    output = Pointer(UInt64).malloc(max_size)
+    err = LibH3.polygon_to_cells(pointerof(geo_polygon), Resolution.new(resolution), flags, output)
+    raise Exception.new("Couldn't fill polygon with cells") if err != 0
+
+    read_array_of_uint64(output, max_size)
+  end
+
+  # Convert a set of H3 cells to a linked multi-polygon structure.
+  #
+  # Returns an array of polygons, where each polygon is an array of loops,
+  # and each loop is an array of coordinate pairs (lat, lng) in degrees.
+  #
+  # @param [Array<Integer>] h3_set An array of valid H3 indexes.
+  #
+  # @example Convert cells to polygon outlines.
+  #   cells = [612933930963697663]
+  #   H3.cells_to_multi_polygon(cells)
+  #
+  # @return [Array<Array<Array<Tuple(Float64, Float64)>>>] Array of polygons (each polygon is an array of loops, each loop is coordinates).
+  def cells_to_multi_polygon(h3_set : Array(UInt64)) : Array(Array(Array(Tuple(Float64, Float64))))
+    linked_polygon = LibH3::LinkedGeoPolygon.new(
+      first: Pointer(LibH3::LinkedGeoLoop).null,
+      last: Pointer(LibH3::LinkedGeoLoop).null,
+      next: Pointer(LibH3::LinkedGeoPolygon).null
+    )
+
+    err = LibH3.cells_to_linked_multi_polygon(h3_set, h3_set.size.to_i32, pointerof(linked_polygon))
+    raise Exception.new("Couldn't convert cells to multi polygon") if err != 0
+
+    result = collect_linked_polygons(pointerof(linked_polygon))
+    LibH3.destroy_linked_multi_polygon(pointerof(linked_polygon))
+
+    result
+  end
+
+  private def build_geo_polygon(polygon : Array(Tuple(Float64, Float64)), holes : Array(Array(Tuple(Float64, Float64)))) : LibH3::GeoPolygon
+    # Convert outer boundary to radians
+    outer_verts = Pointer(LibH3::LatLng).malloc(polygon.size)
+    polygon.each_with_index do |coord, i|
+      outer_verts[i] = LibH3::LatLng.new(
+        lat: degs_to_rads(coord[0]),
+        lng: degs_to_rads(coord[1])
+      )
+    end
+
+    outer_loop = LibH3::GeoLoop.new(
+      num_verts: polygon.size.to_i32,
+      verts: outer_verts
+    )
+
+    # Convert holes to radians
+    if holes.empty?
+      LibH3::GeoPolygon.new(
+        geoloop: outer_loop,
+        num_holes: 0,
+        holes: Pointer(LibH3::GeoLoop).null
+      )
+    else
+      hole_loops = Pointer(LibH3::GeoLoop).malloc(holes.size)
+      holes.each_with_index do |hole, i|
+        hole_verts = Pointer(LibH3::LatLng).malloc(hole.size)
+        hole.each_with_index do |coord, j|
+          hole_verts[j] = LibH3::LatLng.new(
+            lat: degs_to_rads(coord[0]),
+            lng: degs_to_rads(coord[1])
+          )
+        end
+        hole_loops[i] = LibH3::GeoLoop.new(
+          num_verts: hole.size.to_i32,
+          verts: hole_verts
+        )
+      end
+
+      LibH3::GeoPolygon.new(
+        geoloop: outer_loop,
+        num_holes: holes.size.to_i32,
+        holes: hole_loops
+      )
+    end
+  end
+
+  private def collect_linked_polygons(polygon_ptr : Pointer(LibH3::LinkedGeoPolygon)) : Array(Array(Array(Tuple(Float64, Float64))))
+    result = [] of Array(Array(Tuple(Float64, Float64)))
+    current_polygon = polygon_ptr
+
+    while !current_polygon.null?
+      polygon_loops = [] of Array(Tuple(Float64, Float64))
+      current_loop = current_polygon.value.first
+
+      while !current_loop.null?
+        coords = [] of Tuple(Float64, Float64)
+        current_coord = current_loop.value.first
+
+        while !current_coord.null?
+          vertex = current_coord.value.vertex
+          coords << {rads_to_degs(vertex.lat), rads_to_degs(vertex.lng)}
+          current_coord = current_coord.value.next
+        end
+
+        polygon_loops << coords
+        current_loop = current_loop.value.next
+      end
+
+      result << polygon_loops
+      current_polygon = current_polygon.value.next
+    end
+
+    result
+  end
+end


### PR DESCRIPTION
## Summary
- Added GeoPolygon, GeoLoop, and LinkedGeo struct definitions for FFI in `lib_h3.cr`
- Created new Polygon module (`src/h3/polygon.cr`) with `max_polygon_to_cells_size`, `polygon_to_cells`, and `cells_to_multi_polygon` methods
- Added FFI bindings for `maxPolygonToCellsSize`, `polygonToCells`, `cellsToLinkedMultiPolygon`, `destroyLinkedMultiPolygon`
- Added `extend Polygon` to main H3 module
- Created 17 polygon specs covering all methods, holes, round-trips, and error cases

Implements h3-kug

## Test plan
- [x] `crystal spec --verbose` passes all 113 tests (96 existing + 17 new)
- [x] Polygon specs cover all 3 public methods
- [x] `crystal tool format --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)