### PR TITLE
[h3-79i] Add directed edge bindings (new in v4 port)

### DIFF
--- a/spec/h3/edge_spec.cr
+++ b/spec/h3/edge_spec.cr
@@ -1,0 +1,155 @@
+describe H3 do
+  # Use two known neighboring cells at resolution 9
+  origin = "8928308280fffff".to_u64(16)
+  destination = "8928308280bffff".to_u64(16)
+
+  describe ".are_neighbor_cells" do
+    it "returns true for neighboring cells" do
+      H3.are_neighbor_cells(origin, destination).should be_true
+    end
+
+    context "when cells are not neighbors" do
+      it "returns false" do
+        far_away = "89283082993ffff".to_u64(16)
+        H3.are_neighbor_cells(origin, far_away).should be_false
+      end
+    end
+  end
+
+  describe ".cells_to_directed_edge" do
+    it "returns a directed edge index for neighboring cells" do
+      edge = H3.cells_to_directed_edge(origin, destination)
+      edge.should_not eq 0
+      H3.valid_directed_edge?(edge).should be_true
+    end
+  end
+
+  describe ".valid_directed_edge?" do
+    it "returns true for a valid directed edge" do
+      edge = H3.cells_to_directed_edge(origin, destination)
+      H3.valid_directed_edge?(edge).should be_true
+    end
+
+    context "when the index is not a directed edge" do
+      it "returns false" do
+        H3.valid_directed_edge?(origin).should be_false
+      end
+    end
+
+    context "when given an invalid index" do
+      it "returns false" do
+        H3.valid_directed_edge?(0_u64).should be_false
+      end
+    end
+  end
+
+  describe ".directed_edge_origin" do
+    it "returns the origin cell" do
+      edge = H3.cells_to_directed_edge(origin, destination)
+      H3.directed_edge_origin(edge).should eq origin
+    end
+  end
+
+  describe ".directed_edge_destination" do
+    it "returns the destination cell" do
+      edge = H3.cells_to_directed_edge(origin, destination)
+      H3.directed_edge_destination(edge).should eq destination
+    end
+  end
+
+  describe ".directed_edge_to_cells" do
+    it "returns origin and destination cells" do
+      edge = H3.cells_to_directed_edge(origin, destination)
+      cells = H3.directed_edge_to_cells(edge)
+      cells[0].should eq origin
+      cells[1].should eq destination
+    end
+  end
+
+  describe ".origin_to_directed_edges" do
+    it "returns 6 directed edges for a hexagon" do
+      edges = H3.origin_to_directed_edges(origin)
+      edges.size.should eq 6
+    end
+
+    it "returns valid directed edges" do
+      edges = H3.origin_to_directed_edges(origin)
+      edges.each do |edge|
+        H3.valid_directed_edge?(edge).should be_true
+      end
+    end
+
+    it "returns edges that all originate from the given cell" do
+      edges = H3.origin_to_directed_edges(origin)
+      edges.each do |edge|
+        H3.directed_edge_origin(edge).should eq origin
+      end
+    end
+
+    context "when the cell is a pentagon" do
+      it "returns 5 directed edges" do
+        pentagon = "821c07fffffffff".to_u64(16)
+        edges = H3.origin_to_directed_edges(pentagon)
+        edges.size.should eq 5
+      end
+    end
+  end
+
+  describe ".directed_edge_to_boundary" do
+    it "returns boundary coordinates for a directed edge" do
+      edge = H3.cells_to_directed_edge(origin, destination)
+      boundary = H3.directed_edge_to_boundary(edge)
+      boundary.size.should be > 0
+    end
+
+    it "returns valid coordinate pairs" do
+      edge = H3.cells_to_directed_edge(origin, destination)
+      boundary = H3.directed_edge_to_boundary(edge)
+      boundary.each do |(lat, lng)|
+        lat.should be >= -90.0
+        lat.should be <= 90.0
+        lng.should be >= -180.0
+        lng.should be <= 180.0
+      end
+    end
+  end
+
+  describe ".exact_edge_length_rads" do
+    it "returns the edge length in radians" do
+      edge = H3.cells_to_directed_edge(origin, destination)
+      length = H3.exact_edge_length_rads(edge)
+      length.should be > 0.0
+    end
+  end
+
+  describe ".exact_edge_length_km" do
+    it "returns the edge length in kilometres" do
+      edge = H3.cells_to_directed_edge(origin, destination)
+      length = H3.exact_edge_length_km(edge)
+      length.should be > 0.0
+    end
+
+    it "returns a reasonable value" do
+      edge = H3.cells_to_directed_edge(origin, destination)
+      length = H3.exact_edge_length_km(edge)
+      # Resolution 9 edges should be on the order of a fraction of a km
+      length.should be < 1.0
+      length.should be > 0.0
+    end
+  end
+
+  describe ".exact_edge_length_m" do
+    it "returns the edge length in metres" do
+      edge = H3.cells_to_directed_edge(origin, destination)
+      length = H3.exact_edge_length_m(edge)
+      length.should be > 0.0
+    end
+
+    it "is consistent with km measurement" do
+      edge = H3.cells_to_directed_edge(origin, destination)
+      length_m = H3.exact_edge_length_m(edge)
+      length_km = H3.exact_edge_length_km(edge)
+      (length_m / 1000.0).should be_close(length_km, 0.0001)
+    end
+  end
+end

--- a/src/h3.cr
+++ b/src/h3.cr
@@ -9,6 +9,7 @@ require "./h3/inspection"
 require "./h3/traversal"
 require "./h3/hierarchy"
 require "./h3/polygon"
+require "./h3/edge"
 
 module H3
   VERSION = "4.4.1"
@@ -19,4 +20,5 @@ module H3
   extend Traversal
   extend Hierarchy
   extend Polygon
+  extend Edge
 end

--- a/src/h3/bindings/lib_h3.cr
+++ b/src/h3/bindings/lib_h3.cr
@@ -109,6 +109,19 @@ module H3
         fun polygon_to_cells = polygonToCells(geo_polygon : Pointer(GeoPolygon), res : Int32, flags : UInt32, out : H3Index*) : H3Error
         fun cells_to_linked_multi_polygon = cellsToLinkedMultiPolygon(h3_set : H3Index*, num_hexes : Int32, out : Pointer(LinkedGeoPolygon)) : H3Error
         fun destroy_linked_multi_polygon = destroyLinkedMultiPolygon(polygon : Pointer(LinkedGeoPolygon)) : Void
+
+        # Directed Edges
+        fun are_neighbor_cells = areNeighborCells(origin : H3Index, destination : H3Index, out : Int32*) : H3Error
+        fun cells_to_directed_edge = cellsToDirectedEdge(origin : H3Index, destination : H3Index, out : H3Index*) : H3Error
+        fun is_valid_directed_edge = isValidDirectedEdge(edge : H3Index) : Int32
+        fun get_directed_edge_origin = getDirectedEdgeOrigin(edge : H3Index, out : H3Index*) : H3Error
+        fun get_directed_edge_destination = getDirectedEdgeDestination(edge : H3Index, out : H3Index*) : H3Error
+        fun directed_edge_to_cells = directedEdgeToCells(edge : H3Index, origin_destination : H3Index*) : H3Error
+        fun origin_to_directed_edges = originToDirectedEdges(origin : H3Index, edges : H3Index*) : H3Error
+        fun directed_edge_to_boundary = directedEdgeToBoundary(edge : H3Index, gb : Pointer(CellBoundary)) : H3Error
+        fun exact_edge_length_rads = edgeLengthRads(edge : H3Index, length : Float64*) : H3Error
+        fun exact_edge_length_km = edgeLengthKm(edge : H3Index, length : Float64*) : H3Error
+        fun exact_edge_length_m = edgeLengthM(edge : H3Index, length : Float64*) : H3Error
       end
 
       def read_array_of_uint64(ptr : Pointer(UInt64), size : Int) : Array(UInt64)

--- a/src/h3/edge.cr
+++ b/src/h3/edge.cr
@@ -1,0 +1,209 @@
+require "./bindings/base"
+require "./miscellaneous"
+
+module Edge
+  include H3::Bindings::Base
+  include Miscellaneous
+
+  # @!method are_neighbor_cells(origin, destination)
+  #
+  # Determine whether two H3 indexes are neighbors.
+  #
+  # @param [Integer] origin Origin H3 index.
+  # @param [Integer] destination Destination H3 index.
+  #
+  # @example Check if two indexes are neighbors.
+  #   H3.are_neighbor_cells(617700169983721471, 617700169982672895)
+  #   true
+  #
+  # @return [Boolean] True if the indexes are neighbors.
+  def are_neighbor_cells(origin : UInt64, destination : UInt64) : Bool
+    result = 0_i32
+    err = LibH3.are_neighbor_cells(origin, destination, pointerof(result))
+    raise Exception.new("Couldn't determine if cells are neighbors") if err != 0
+    result != 0
+  end
+
+  # @!method cells_to_directed_edge(origin, destination)
+  #
+  # Derive the directed edge H3 index for the given origin and destination pair.
+  #
+  # @param [Integer] origin Origin H3 index.
+  # @param [Integer] destination Destination H3 index.
+  #
+  # @example Get the directed edge between two neighbors.
+  #   H3.cells_to_directed_edge(617700169983721471, 617700169982672895)
+  #   1608700169983721471
+  #
+  # @raise [Exception] If the cells are not neighbors.
+  #
+  # @return [Integer] H3 index of the directed edge.
+  def cells_to_directed_edge(origin : UInt64, destination : UInt64) : UInt64
+    edge = 0_u64
+    err = LibH3.cells_to_directed_edge(origin, destination, pointerof(edge))
+    raise Exception.new("Couldn't get directed edge for given cells") if err != 0
+    edge
+  end
+
+  # @!method valid_directed_edge?(edge)
+  #
+  # Determine whether the given H3 index is a valid directed edge.
+  #
+  # @param [Integer] edge A H3 index.
+  #
+  # @example Check if the H3 index is a valid directed edge.
+  #   H3.valid_directed_edge?(1608700169983721471)
+  #   true
+  #
+  # @return [Boolean] True if the H3 index is a valid directed edge.
+  def valid_directed_edge?(edge : UInt64) : Bool
+    LibH3.is_valid_directed_edge(edge) != 0
+  end
+
+  # @!method directed_edge_origin(edge)
+  #
+  # Returns the origin cell from the given directed edge.
+  #
+  # @param [Integer] edge A valid directed edge H3 index.
+  #
+  # @example Get the origin cell of a directed edge.
+  #   H3.directed_edge_origin(1608700169983721471)
+  #   617700169983721471
+  #
+  # @return [Integer] H3 index of the origin cell.
+  def directed_edge_origin(edge : UInt64) : UInt64
+    origin = 0_u64
+    err = LibH3.get_directed_edge_origin(edge, pointerof(origin))
+    raise Exception.new("Couldn't get origin for directed edge") if err != 0
+    origin
+  end
+
+  # @!method directed_edge_destination(edge)
+  #
+  # Returns the destination cell from the given directed edge.
+  #
+  # @param [Integer] edge A valid directed edge H3 index.
+  #
+  # @example Get the destination cell of a directed edge.
+  #   H3.directed_edge_destination(1608700169983721471)
+  #   617700169982672895
+  #
+  # @return [Integer] H3 index of the destination cell.
+  def directed_edge_destination(edge : UInt64) : UInt64
+    destination = 0_u64
+    err = LibH3.get_directed_edge_destination(edge, pointerof(destination))
+    raise Exception.new("Couldn't get destination for directed edge") if err != 0
+    destination
+  end
+
+  # @!method directed_edge_to_cells(edge)
+  #
+  # Returns the origin and destination cells from the given directed edge.
+  #
+  # @param [Integer] edge A valid directed edge H3 index.
+  #
+  # @example Get both cells of a directed edge.
+  #   H3.directed_edge_to_cells(1608700169983721471)
+  #   {617700169983721471, 617700169982672895}
+  #
+  # @return [Tuple(UInt64, UInt64)] Origin and destination H3 indexes.
+  def directed_edge_to_cells(edge : UInt64) : Tuple(UInt64, UInt64)
+    cells = Pointer(UInt64).malloc(2)
+    err = LibH3.directed_edge_to_cells(edge, cells)
+    raise Exception.new("Couldn't get cells for directed edge") if err != 0
+    {cells[0], cells[1]}
+  end
+
+  # @!method origin_to_directed_edges(origin)
+  #
+  # Returns all directed edges originating from the given cell.
+  #
+  # @param [Integer] origin A valid H3 index.
+  #
+  # @example Get all directed edges from a cell.
+  #   H3.origin_to_directed_edges(617700169983721471)
+  #   [1608700169983721471, ...]
+  #
+  # @return [Array<Integer>] Array of directed edge H3 indexes (6 for hexagons, 5 for pentagons).
+  def origin_to_directed_edges(origin : UInt64) : Array(UInt64)
+    edges = Pointer(UInt64).malloc(6)
+    err = LibH3.origin_to_directed_edges(origin, edges)
+    raise Exception.new("Couldn't get directed edges for origin") if err != 0
+    read_array_of_uint64(edges, 6)
+  end
+
+  # @!method directed_edge_to_boundary(edge)
+  #
+  # Returns the coordinates of the directed edge boundary.
+  #
+  # @param [Integer] edge A valid directed edge H3 index.
+  #
+  # @example Get the boundary of a directed edge.
+  #   H3.directed_edge_to_boundary(1608700169983721471)
+  #   [{lat1, lng1}, {lat2, lng2}]
+  #
+  # @return [Array<Tuple(Float64, Float64)>] Array of coordinate pairs.
+  def directed_edge_to_boundary(edge : UInt64) : Array(Tuple(Float64, Float64))
+    geo_boundary = LibH3::CellBoundary.new(num_verts: 0, verts: StaticArray(LibH3::LatLng, 10).new(LibH3::LatLng.new(lat: 0.0, lng: 0.0)))
+    err = LibH3.directed_edge_to_boundary(edge, pointerof(geo_boundary))
+    raise Exception.new("Couldn't get boundary for directed edge") if err != 0
+
+    geo_boundary.verts.first(geo_boundary.num_verts).map do |vertex|
+      {rads_to_degs(vertex.lat), rads_to_degs(vertex.lng)}
+    end
+  end
+
+  # @!method exact_edge_length_rads(edge)
+  #
+  # Returns the exact length of the given directed edge in radians.
+  #
+  # @param [Integer] edge A valid directed edge H3 index.
+  #
+  # @example Get edge length in radians.
+  #   H3.exact_edge_length_rads(1608700169983721471)
+  #   0.001234
+  #
+  # @return [Float] Edge length in radians.
+  def exact_edge_length_rads(edge : UInt64) : Float64
+    length = 0.0
+    err = LibH3.exact_edge_length_rads(edge, pointerof(length))
+    raise Exception.new("Couldn't get edge length in radians") if err != 0
+    length
+  end
+
+  # @!method exact_edge_length_km(edge)
+  #
+  # Returns the exact length of the given directed edge in kilometres.
+  #
+  # @param [Integer] edge A valid directed edge H3 index.
+  #
+  # @example Get edge length in kilometres.
+  #   H3.exact_edge_length_km(1608700169983721471)
+  #   7.86
+  #
+  # @return [Float] Edge length in kilometres.
+  def exact_edge_length_km(edge : UInt64) : Float64
+    length = 0.0
+    err = LibH3.exact_edge_length_km(edge, pointerof(length))
+    raise Exception.new("Couldn't get edge length in kilometres") if err != 0
+    length
+  end
+
+  # @!method exact_edge_length_m(edge)
+  #
+  # Returns the exact length of the given directed edge in metres.
+  #
+  # @param [Integer] edge A valid directed edge H3 index.
+  #
+  # @example Get edge length in metres.
+  #   H3.exact_edge_length_m(1608700169983721471)
+  #   7860.0
+  #
+  # @return [Float] Edge length in metres.
+  def exact_edge_length_m(edge : UInt64) : Float64
+    length = 0.0
+    err = LibH3.exact_edge_length_m(edge, pointerof(length))
+    raise Exception.new("Couldn't get edge length in metres") if err != 0
+    length
+  end
+end


### PR DESCRIPTION
## Summary
- Created new Edge module (`src/h3/edge.cr`) with 11 wrapper methods
- Added FFI bindings for all directed edge and edge measurement functions to `lib_h3.cr`
- Added `extend Edge` to main H3 module
- Created comprehensive edge specs

Implements h3-79i

## Test plan
- [ ] `crystal spec --verbose` passes all tests
- [ ] Edge specs cover all 11 functions
- [ ] `crystal tool format --check` passes