### PR TITLE
[h3-g3r] Add vertex and local IJ coordinate bindings

### DIFF
--- a/spec/h3/vertex_spec.cr
+++ b/spec/h3/vertex_spec.cr
@@ -1,0 +1,120 @@
+describe H3 do
+  # Use a known valid hex cell at resolution 9
+  origin = "8928308280fffff".to_u64(16)
+
+  describe ".cell_to_vertex" do
+    it "returns a valid vertex index for vertex 0" do
+      vertex = H3.cell_to_vertex(origin, 0)
+      vertex.should_not eq 0
+      H3.valid_vertex?(vertex).should be_true
+    end
+
+    it "returns valid vertex indexes for all 6 vertices of a hexagon" do
+      6.times do |i|
+        vertex = H3.cell_to_vertex(origin, i)
+        vertex.should_not eq 0
+        H3.valid_vertex?(vertex).should be_true
+      end
+    end
+
+    it "returns different vertex indexes for different vertex numbers" do
+      vertices = (0...6).map { |i| H3.cell_to_vertex(origin, i) }
+      vertices.uniq.size.should eq 6
+    end
+  end
+
+  describe ".cell_to_vertexes" do
+    it "returns 6 vertices for a hexagonal cell" do
+      vertexes = H3.cell_to_vertexes(origin)
+      vertexes.size.should eq 6
+    end
+
+    it "returns all valid vertex indexes" do
+      vertexes = H3.cell_to_vertexes(origin)
+      vertexes.each do |vertex|
+        H3.valid_vertex?(vertex).should be_true
+      end
+    end
+
+    context "when the cell is a pentagon" do
+      it "returns 5 vertices" do
+        pentagon = "821c07fffffffff".to_u64(16)
+        vertexes = H3.cell_to_vertexes(pentagon)
+        vertexes.size.should eq 5
+      end
+    end
+  end
+
+  describe ".vertex_to_lat_lng" do
+    it "returns valid coordinates for a vertex" do
+      vertex = H3.cell_to_vertex(origin, 0)
+      lat, lng = H3.vertex_to_lat_lng(vertex)
+      lat.should be >= -90.0
+      lat.should be <= 90.0
+      lng.should be >= -180.0
+      lng.should be <= 180.0
+    end
+
+    it "returns different coordinates for different vertices" do
+      vertex0 = H3.cell_to_vertex(origin, 0)
+      vertex1 = H3.cell_to_vertex(origin, 1)
+      coords0 = H3.vertex_to_lat_lng(vertex0)
+      coords1 = H3.vertex_to_lat_lng(vertex1)
+      coords0.should_not eq coords1
+    end
+  end
+
+  describe ".valid_vertex?" do
+    it "returns true for a valid vertex" do
+      vertex = H3.cell_to_vertex(origin, 0)
+      H3.valid_vertex?(vertex).should be_true
+    end
+
+    context "when given a cell index instead of a vertex" do
+      it "returns false" do
+        H3.valid_vertex?(origin).should be_false
+      end
+    end
+
+    context "when given an invalid index" do
+      it "returns false" do
+        H3.valid_vertex?(0_u64).should be_false
+      end
+    end
+  end
+
+  describe ".cell_to_local_ij" do
+    it "converts a cell to IJ coordinates relative to an origin" do
+      # Use a neighbor of origin
+      neighbor = H3.k_ring(origin, 1).reject { |h| h == origin }.first
+      i, j = H3.cell_to_local_ij(origin, neighbor)
+      # The neighbor should have non-zero IJ coordinates relative to origin
+      (i != 0 || j != 0).should be_true
+    end
+
+    it "returns consistent IJ coordinates for the origin cell itself" do
+      i, j = H3.cell_to_local_ij(origin, origin)
+      # The origin relative to itself should round-trip back
+      result = H3.local_ij_to_cell(origin, {i, j})
+      result.should eq origin
+    end
+  end
+
+  describe ".local_ij_to_cell" do
+    it "converts IJ coordinates back to a cell index" do
+      neighbor = H3.k_ring(origin, 1).reject { |h| h == origin }.first
+      ij = H3.cell_to_local_ij(origin, neighbor)
+      result = H3.local_ij_to_cell(origin, ij)
+      result.should eq neighbor
+    end
+
+    it "round-trips through cell_to_local_ij and back" do
+      neighbors = H3.k_ring(origin, 1)
+      neighbors.each do |cell|
+        ij = H3.cell_to_local_ij(origin, cell)
+        result = H3.local_ij_to_cell(origin, ij)
+        result.should eq cell
+      end
+    end
+  end
+end

--- a/src/h3.cr
+++ b/src/h3.cr
@@ -10,6 +10,7 @@ require "./h3/traversal"
 require "./h3/hierarchy"
 require "./h3/polygon"
 require "./h3/edge"
+require "./h3/vertex"
 
 module H3
   VERSION = "4.4.1"
@@ -21,4 +22,5 @@ module H3
   extend Hierarchy
   extend Polygon
   extend Edge
+  extend Vertex
 end

--- a/src/h3/bindings/lib_h3.cr
+++ b/src/h3/bindings/lib_h3.cr
@@ -52,6 +52,11 @@ module H3
           next : Pointer(LinkedGeoPolygon)
         end
 
+        struct CoordIJ
+          i : Int32
+          j : Int32
+        end
+
         # Misc
         fun degs_to_rads = degsToRads(degrees : Float64) : Float64
         fun rads_to_degs = radsToDegs(rads : Float64) : Float64
@@ -109,6 +114,16 @@ module H3
         fun polygon_to_cells = polygonToCells(geo_polygon : Pointer(GeoPolygon), res : Int32, flags : UInt32, out : H3Index*) : H3Error
         fun cells_to_linked_multi_polygon = cellsToLinkedMultiPolygon(h3_set : H3Index*, num_hexes : Int32, out : Pointer(LinkedGeoPolygon)) : H3Error
         fun destroy_linked_multi_polygon = destroyLinkedMultiPolygon(polygon : Pointer(LinkedGeoPolygon)) : Void
+
+        # Vertex
+        fun cell_to_vertex = cellToVertex(origin : H3Index, vertex_num : Int32, out : H3Index*) : H3Error
+        fun cell_to_vertexes = cellToVertexes(origin : H3Index, out : H3Index*) : H3Error
+        fun vertex_to_lat_lng = vertexToLatLng(vertex : H3Index, out : Pointer(LatLng)) : H3Error
+        fun is_valid_vertex = isValidVertex(vertex : H3Index) : Int32
+
+        # Local IJ Coordinates
+        fun cell_to_local_ij = cellToLocalIj(origin : H3Index, h3 : H3Index, mode : UInt32, out : CoordIJ*) : H3Error
+        fun local_ij_to_cell = localIjToCell(origin : H3Index, ij : CoordIJ*, mode : UInt32, out : H3Index*) : H3Error
 
         # Directed Edges
         fun are_neighbor_cells = areNeighborCells(origin : H3Index, destination : H3Index, out : Int32*) : H3Error

--- a/src/h3/vertex.cr
+++ b/src/h3/vertex.cr
@@ -1,0 +1,121 @@
+require "./bindings/base"
+require "./miscellaneous"
+
+module Vertex
+  include H3::Bindings::Base
+  include Miscellaneous
+
+  # Returns the vertex index for the given cell and vertex number.
+  #
+  # @param [Integer] origin A valid H3 cell index.
+  # @param [Integer] vertex_num The vertex number (0-5 for hexagons, 0-4 for pentagons).
+  #
+  # @example Get vertex 0 of a cell.
+  #   H3.cell_to_vertex(612933930963697663, 0)
+  #
+  # @raise [Exception] If the vertex number is invalid for the cell.
+  #
+  # @return [Integer] H3 vertex index.
+  def cell_to_vertex(origin : UInt64, vertex_num : Int32) : UInt64
+    vertex = 0_u64
+    err = LibH3.cell_to_vertex(origin, vertex_num, pointerof(vertex))
+    raise Exception.new("Couldn't get vertex for cell") if err != 0
+    vertex
+  end
+
+  # Returns all vertex indexes for the given cell.
+  #
+  # Hexagonal cells have 6 vertices. Pentagonal cells have 5 vertices.
+  # The output array is allocated with 6 elements; for pentagons, one
+  # element will be zero and is filtered out.
+  #
+  # @param [Integer] origin A valid H3 cell index.
+  #
+  # @example Get all vertices of a cell.
+  #   H3.cell_to_vertexes(612933930963697663)
+  #
+  # @raise [Exception] If the operation fails.
+  #
+  # @return [Array<Integer>] Array of H3 vertex indexes.
+  def cell_to_vertexes(origin : UInt64) : Array(UInt64)
+    vertexes = Pointer(UInt64).malloc(6)
+    err = LibH3.cell_to_vertexes(origin, vertexes)
+    raise Exception.new("Couldn't get vertexes for cell") if err != 0
+    read_array_of_uint64(vertexes, 6)
+  end
+
+  # Returns the latitude and longitude of the given vertex in degrees.
+  #
+  # @param [Integer] vertex A valid H3 vertex index.
+  #
+  # @example Get the coordinates of a vertex.
+  #   H3.vertex_to_lat_lng(vertex_index)
+  #   {lat, lng}
+  #
+  # @raise [Exception] If the vertex is invalid.
+  #
+  # @return [Tuple(Float64, Float64)] Latitude and longitude in degrees.
+  def vertex_to_lat_lng(vertex : UInt64) : Tuple(Float64, Float64)
+    coords = LibH3::LatLng.new(lat: 0.0, lng: 0.0)
+    err = LibH3.vertex_to_lat_lng(vertex, pointerof(coords))
+    raise Exception.new("Couldn't get coordinates for vertex") if err != 0
+    {rads_to_degs(coords.lat), rads_to_degs(coords.lng)}
+  end
+
+  # Determines whether the given H3 index is a valid vertex.
+  #
+  # @param [Integer] vertex A H3 index.
+  #
+  # @example Check if an index is a valid vertex.
+  #   H3.valid_vertex?(vertex_index)
+  #   true
+  #
+  # @return [Boolean] True if the H3 index is a valid vertex.
+  def valid_vertex?(vertex : UInt64) : Bool
+    LibH3.is_valid_vertex(vertex) != 0
+  end
+
+  # Converts an H3 cell index to local IJ coordinates relative to an origin cell.
+  #
+  # The mode parameter controls the coordinate system behavior. Use 0 for default.
+  #
+  # @param [Integer] origin Origin H3 cell index.
+  # @param [Integer] h3 Target H3 cell index.
+  # @param [Integer] mode Coordinate system mode (default 0).
+  #
+  # @example Convert cell to local IJ coordinates.
+  #   H3.cell_to_local_ij(origin, target)
+  #   {i, j}
+  #
+  # @raise [Exception] If the conversion fails (e.g., cells are too far apart or a pentagon is encountered).
+  #
+  # @return [Tuple(Int32, Int32)] IJ coordinates as {i, j}.
+  def cell_to_local_ij(origin : UInt64, h3 : UInt64, mode : UInt32 = 0_u32) : Tuple(Int32, Int32)
+    coord = LibH3::CoordIJ.new(i: 0, j: 0)
+    err = LibH3.cell_to_local_ij(origin, h3, mode, pointerof(coord))
+    raise Exception.new("Couldn't convert cell to local IJ coordinates") if err != 0
+    {coord.i, coord.j}
+  end
+
+  # Converts local IJ coordinates to an H3 cell index relative to an origin cell.
+  #
+  # The mode parameter controls the coordinate system behavior. Use 0 for default.
+  #
+  # @param [Integer] origin Origin H3 cell index.
+  # @param [Tuple(Int32, Int32)] ij IJ coordinates as {i, j}.
+  # @param [Integer] mode Coordinate system mode (default 0).
+  #
+  # @example Convert local IJ coordinates back to a cell.
+  #   H3.local_ij_to_cell(origin, {1, 2})
+  #
+  # @raise [Exception] If the conversion fails.
+  #
+  # @return [Integer] H3 cell index.
+  def local_ij_to_cell(origin : UInt64, ij : Tuple(Int32, Int32), mode : UInt32 = 0_u32) : UInt64
+    coord = LibH3::CoordIJ.new(i: ij[0], j: ij[1])
+    result = 0_u64
+    err = LibH3.local_ij_to_cell(origin, pointerof(coord), mode, pointerof(result))
+    raise Exception.new("Couldn't convert local IJ coordinates to cell") if err != 0
+    result
+  end
+end


### PR DESCRIPTION
## Summary
- Add FFI bindings for cellToVertex, cellToVertexes, vertexToLatLng, isValidVertex
- Add FFI bindings for cellToLocalIj, localIjToCell with CoordIJ struct
- Add wrapper methods with degree/radian conversion for vertex coordinates
- Add comprehensive specs for all 6 new functions

Implements h3-g3r

## Test plan
- [x] cellToVertex returns valid vertex index for each vertex number
- [x] cellToVertexes returns all vertices for a hexagonal cell
- [x] vertexToLatLng returns valid coordinates for a vertex
- [x] isValidVertex correctly identifies valid and invalid vertex indices
- [x] cellToLocalIj converts cell to IJ coordinates relative to origin
- [x] localIjToCell converts IJ coordinates back to cell index
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)